### PR TITLE
Streamline webhook payload handling and logging

### DIFF
--- a/app/texts.py
+++ b/app/texts.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 from typing import Any, Dict, Optional
 
@@ -22,6 +23,8 @@ TEXTS: Dict[str, Any] = {}
 
 # Кэш времени последней модификации файла, чтобы не читать его лишний раз
 _LAST_MTIME: Optional[float] = None
+
+logger = logging.getLogger(__name__)
 
 
 # ---------------------------
@@ -90,9 +93,8 @@ def load_texts(force: bool = False) -> None:
         TEXTS.clear()
         _deep_update(TEXTS, data)
         _LAST_MTIME = mtime
-    except Exception as e:
-        # Логгер здесь не используем специально, чтобы модуль был «чистым».
-        print(f"[texts] Ошибка загрузки {path}: {e}")
+    except Exception:
+        logger.exception("Failed to load texts from %s", path)
 
 
 def save_texts() -> None:
@@ -110,8 +112,8 @@ def save_texts() -> None:
             _LAST_MTIME = os.path.getmtime(path)
         except OSError:
             pass
-    except Exception as e:
-        print(f"[texts] Ошибка сохранения {path}: {e}")
+    except Exception:
+        logger.exception("Failed to save texts to %s", path)
 
 
 # ---------------------------

--- a/app/webhook.py
+++ b/app/webhook.py
@@ -3,177 +3,128 @@ Webhook сервис для интеграции с n8n
 Отправляет данные о пользователях в Google Sheets через n8n Webhook
 """
 
-import aiohttp
 import asyncio
-from datetime import datetime
 import logging
-from typing import Union, Dict, Any
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any, Dict, Union
 
-# Import from the correct location
+import aiohttp
+
 from app.database.models import User
-from config import N8N_WEBHOOK_URL, DEBUG, N8N_WEBHOOK_SECRET
+from config import DEBUG, N8N_WEBHOOK_SECRET, N8N_WEBHOOK_URL
 
 logger = logging.getLogger(__name__)
 
+_USER_FIELDS_DEFAULTS: Dict[str, Any] = {
+    "tg_id": 0,
+    "username": "",
+    "first_name": "",
+    "gender": "",
+    "age": 0,
+    "weight": 0.0,
+    "height": 0,
+    "activity": "",
+    "goal": "",
+    "calories": 0,
+    "proteins": 0,
+    "fats": 0,
+    "carbs": 0,
+    "funnel_status": "",
+    "priority": "",
+    "priority_score": 0,
+    "created_at": None,
+    "updated_at": None,
+    "calculated_at": None,
+}
 
-async def send_lead_to_n8n(user: User, event: str = "kbju_lead") -> bool:
-    """
-    Отправить данные пользователя в n8n Webhook.
-    
-    Args:
-        user: объект User из БД
-        event: название события (по умолчанию kbju_lead)
-    Returns:
-        bool: успешно ли отправлено
-    """
+_DATETIME_FIELDS = {"created_at", "updated_at", "calculated_at"}
 
+
+def _normalize_user_payload(source: Union[User, Mapping[str, Any]], event: str) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    for field, default in _USER_FIELDS_DEFAULTS.items():
+        if isinstance(source, Mapping):
+            value = source.get(field, default)
+        else:
+            value = getattr(source, field, default)
+
+        if field in _DATETIME_FIELDS and value is not None:
+            if isinstance(value, datetime):
+                value = value.isoformat()
+            else:
+                value = str(value)
+
+        payload[field] = value if value is not None else default
+
+    payload["event"] = event
+    payload["timestamp"] = datetime.utcnow().isoformat()
+    return payload
+
+
+def _build_headers() -> Dict[str, str]:
+    headers = {"Content-Type": "application/json"}
+    if N8N_WEBHOOK_SECRET:
+        headers["X-Webhook-Secret"] = N8N_WEBHOOK_SECRET
+    return headers
+
+
+async def _send_with_retry(payload: Dict[str, Any]) -> bool:
     if not N8N_WEBHOOK_URL:
-        if DEBUG:
-            print("[Webhook] ⚠️ N8N_WEBHOOK_URL не задан — данные не отправлены")
+        logger.warning("N8N_WEBHOOK_URL is not set; skip sending event %s", payload.get("event"))
         return False
 
-    # Формируем payload под n8n
-    payload = {
-        "tg_id": user.tg_id,
-        "username": user.username,
-        "first_name": user.first_name,
-        "gender": user.gender,
-        "age": user.age,
-        "weight": user.weight,
-        "height": user.height,
-        "activity": user.activity,
-        "goal": user.goal,
-        "calories": user.calories,
-        "proteins": user.proteins,
-        "fats": user.fats,
-        "carbs": user.carbs,
-        "funnel_status": user.funnel_status,
-        "priority": user.priority,
-        "priority_score": user.priority_score,
-        "created_at": user.created_at.isoformat() if user.created_at else None,
-        "updated_at": user.updated_at.isoformat() if user.updated_at else None,
-        "calculated_at": user.calculated_at.isoformat() if user.calculated_at else None,
-        "event": event,
-        "timestamp": datetime.utcnow().isoformat(),
-    }
-
-    # Retry логика: до 3 попыток
+    headers = _build_headers()
     for attempt in range(3):
         try:
             timeout = aiohttp.ClientTimeout(total=5 + attempt * 2)
             async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.post(
-                    N8N_WEBHOOK_URL,
-                    json=payload,
-                    headers={
-                        "Content-Type": "application/json",
-                        "X-Webhook-Secret": N8N_WEBHOOK_SECRET
-                    },
-                ) as resp:
+                async with session.post(N8N_WEBHOOK_URL, json=payload, headers=headers) as resp:
                     text = await resp.text()
                     if resp.status == 200:
                         if DEBUG:
-                            print(
-                                f"[Webhook] ✅ Lead {user.tg_id} отправлен в n8n "
-                                f"(попытка {attempt + 1}): {text}"
+                            logger.debug(
+                                "Lead %s sent to n8n on attempt %s: %s",
+                                payload.get("tg_id"),
+                                attempt + 1,
+                                text,
                             )
                         return True
-                    else:
-                        print(
-                            f"[Webhook] ❌ Ошибка {resp.status} при отправке "
-                            f"(попытка {attempt + 1}): {text}"
-                        )
-        except Exception as e:
-            print(f"[Webhook] 🔥 Ошибка на попытке {attempt + 1}: {e}")
 
-        # backoff
+                    logger.warning(
+                        "Unexpected status %s from n8n on attempt %s: %s",
+                        resp.status,
+                        attempt + 1,
+                        text,
+                    )
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Webhook request timed out on attempt %s for lead %s",
+                attempt + 1,
+                payload.get("tg_id"),
+            )
+        except Exception:
+            logger.exception(
+                "Webhook request failed on attempt %s for lead %s",
+                attempt + 1,
+                payload.get("tg_id"),
+            )
+
         if attempt < 2:
-            delay = 2 ** attempt  # 1с, 2с
-            await asyncio.sleep(delay)
+            await asyncio.sleep(2 ** attempt)
 
     return False
 
 
-async def send_lead_dict_to_n8n(user_data: Dict[str, Any], event: str = "kbju_lead") -> bool:
-    """
-    Отправить данные пользователя из словаря в n8n Webhook.
-    
-    Args:
-        user_data: словарь с данными пользователя
-        event: название события (по умолчанию kbju_lead)
-    Returns:
-        bool: успешно ли отправлено
-    """
-
-    if not N8N_WEBHOOK_URL:
-        if DEBUG:
-            print("[Webhook] ⚠️ N8N_WEBHOOK_URL не задан — данные не отправлены")
-        return False
-
-    # Формируем payload под n8n
-    payload = {
-        "tg_id": user_data.get("tg_id", 0),
-        "username": user_data.get("username", ""),
-        "first_name": user_data.get("first_name", ""),
-        "gender": user_data.get("gender", ""),
-        "age": user_data.get("age", 0),
-        "weight": user_data.get("weight", 0.0),
-        "height": user_data.get("height", 0),
-        "activity": user_data.get("activity", ""),
-        "goal": user_data.get("goal", ""),
-        "calories": user_data.get("calories", 0),
-        "proteins": user_data.get("proteins", 0),
-        "fats": user_data.get("fats", 0),
-        "carbs": user_data.get("carbs", 0),
-        "funnel_status": user_data.get("funnel_status", ""),
-        "priority": user_data.get("priority", ""),
-        "priority_score": user_data.get("priority_score", 0),
-        "created_at": user_data.get("created_at", None),
-        "updated_at": user_data.get("updated_at", None),
-        "calculated_at": user_data.get("calculated_at", None),
-        "event": event,
-        "timestamp": datetime.utcnow().isoformat(),
-    }
-
-    # Retry логика: до 3 попыток
-    for attempt in range(3):
-        try:
-            timeout = aiohttp.ClientTimeout(total=5 + attempt * 2)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.post(
-                    N8N_WEBHOOK_URL,
-                    json=payload,
-                    headers={
-                        "Content-Type": "application/json",
-                        "X-Webhook-Secret": N8N_WEBHOOK_SECRET
-                    },
-                ) as resp:
-                    text = await resp.text()
-                    if resp.status == 200:
-                        if DEBUG:
-                            print(
-                                f"[Webhook] ✅ Lead {payload['tg_id']} отправлен в n8n "
-                                f"(попытка {attempt + 1}): {text}"
-                            )
-                        return True
-                    else:
-                        print(
-                            f"[Webhook] ❌ Ошибка {resp.status} при отправке "
-                            f"(попытка {attempt + 1}): {text}"
-                        )
-        except Exception as e:
-            print(f"[Webhook] 🔥 Ошибка на попытке {attempt + 1}: {e}")
-
-        # backoff
-        if attempt < 2:
-            delay = 2 ** attempt  # 1с, 2с
-            await asyncio.sleep(delay)
-
-    return False
+async def send_lead(
+    source: Union[User, Mapping[str, Any]],
+    event: str = "kbju_lead",
+) -> bool:
+    payload = _normalize_user_payload(source, event)
+    return await _send_with_retry(payload)
 
 
-# Утилита для проверки соединения
-async def test_webhook_connection():
+async def test_webhook_connection() -> bool:
     test_payload = {
         "tg_id": "99999",
         "username": "test_user",
@@ -191,85 +142,69 @@ async def test_webhook_connection():
         "funnel_status": "test",
         "priority": "nutrition",
         "priority_score": 50,
-        "created_at": datetime.utcnow().isoformat(),
-        "updated_at": datetime.utcnow().isoformat(),
-        "calculated_at": datetime.utcnow().isoformat(),
-        "event": "kbju_lead_test",
-        "timestamp": datetime.utcnow().isoformat(),
+        "created_at": datetime.utcnow(),
+        "updated_at": datetime.utcnow(),
+        "calculated_at": datetime.utcnow(),
     }
-    async with aiohttp.ClientSession() as session:
-        async with session.post(
-            N8N_WEBHOOK_URL, json=test_payload, headers={"Content-Type": "application/json"}
-        ) as resp:
-            text = await resp.text()
-            print(f"[Webhook Test] {resp.status}: {text}")
+
+    result = await send_lead(test_payload, "kbju_lead_test")
+    if not result:
+        logger.warning("Webhook connectivity test failed")
+    return result
 
 
 class WebhookService:
-    """Сервис для отправки webhook-ов в n8n"""
-    
+    """Сервис для отправки webhook-ов в n8n."""
+
     @staticmethod
     async def send_lead_to_n8n(user: User, event: str = "kbju_lead") -> bool:
-        """Отправить данные пользователя в n8n Webhook"""
-        return await send_lead_to_n8n(user, event)
-    
+        return await send_lead(user, event)
+
     @staticmethod
-    async def send_hot_lead(user_data: dict, priority: str):
-        """Отправить горячий лид"""
-        # Add the priority to the funnel_status for hot leads
-        user_data["funnel_status"] = f"hotlead_{priority}"
-        return await send_lead_dict_to_n8n(user_data, "hot_lead")
-    
+    async def send_hot_lead(user_data: Mapping[str, Any], priority: str):
+        payload: Dict[str, Any] = dict(user_data)
+        payload["funnel_status"] = f"hotlead_{priority}"
+        return await send_lead(payload, "hot_lead")
+
     @staticmethod
-    async def send_cold_lead(user_data: dict):
-        """Отправить холодный лид"""
-        if "funnel_status" not in user_data:
-            user_data["funnel_status"] = "coldlead"
-        return await send_lead_dict_to_n8n(user_data, "cold_lead")
-    
+    async def send_cold_lead(user_data: Mapping[str, Any]):
+        payload: Dict[str, Any] = dict(user_data)
+        payload["funnel_status"] = "coldlead"
+        return await send_lead(payload, "cold_lead")
+
     @staticmethod
-    async def send_calculated_lead(user_data: dict):
-        """Отправить calculated лид"""
-        if "funnel_status" not in user_data:
-            user_data["funnel_status"] = "calculated"
-        return await send_lead_dict_to_n8n(user_data, "calculated_lead")
+    async def send_calculated_lead(user_data: Mapping[str, Any]):
+        payload: Dict[str, Any] = dict(user_data)
+        payload["funnel_status"] = "calculated"
+        return await send_lead(payload, "calculated_lead")
 
 
 class TimerService:
-    """Сервис для работы с таймерами"""
-    
-    active_timers = {}
-    
+    """Сервис для работы с таймерами."""
+
+    active_timers: Dict[int, asyncio.Task] = {}
+
     @classmethod
     async def start_calculated_timer(cls, user_id: int, delay_minutes: int = 60):
-        """Запустить таймер для пользователя"""
-        # Отменяем предыдущий таймер если есть
         cls.cancel_timer(user_id)
-        
+
         async def timer_callback():
-            await asyncio.sleep(delay_minutes * 60)  # конвертируем в секунды
-            
-            # Здесь должна быть логика обработки таймера
-            # Пока просто логируем
-            if DEBUG:
-                print(f"[TIMER] Таймер сработал для пользователя {user_id}")
-            
-            # Удаляем таймер из активных
-            cls.active_timers.pop(user_id, None)
-        
-        # Создаем и запускаем таймер
+            try:
+                await asyncio.sleep(delay_minutes * 60)
+                logger.debug("Timer fired for user %s after %s minutes", user_id, delay_minutes)
+            except asyncio.CancelledError:
+                logger.debug("Timer for user %s was cancelled", user_id)
+            finally:
+                cls.active_timers.pop(user_id, None)
+
         task = asyncio.create_task(timer_callback())
         cls.active_timers[user_id] = task
-        
-        if DEBUG:
-            print(f"[TIMER] Запущен таймер на {delay_minutes} мин для пользователя {user_id}")
-    
+        logger.debug("Started timer for user %s (%s minutes)", user_id, delay_minutes)
+
     @classmethod
     def cancel_timer(cls, user_id: int):
-        """Отменить таймер для пользователя"""
-        if user_id in cls.active_timers:
-            cls.active_timers[user_id].cancel()
-            del cls.active_timers[user_id]
-            
-            if DEBUG:
-                print(f"[TIMER] Отменен таймер для пользователя {user_id}")
+        task = cls.active_timers.pop(user_id, None)
+        if task and not task.done():
+            task.cancel()
+            logger.debug("Cancelled timer for user %s", user_id)
+


### PR DESCRIPTION
## Summary
- collapse duplicate webhook send helpers into a single `send_lead` utility used by the service facade and connectivity self-test
- avoid mutating caller data when enriching lead payloads and ensure deterministic funnel statuses for hot, cold, and calculated leads
- switch the texts module to structured logging for load/save failures instead of printing to stdout

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cc46b2ff9c8321bbf190d22d576f0a