### PR TITLE
Improve lead notifications with contact workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Конфигурация Telegram бота
 BOT_TOKEN=your_bot_token_here
+ADMIN_CHAT_ID=310151740
 
 # URL базы данных (SQLite по умолчанию)
 DB_URL=sqlite+aiosqlite:///db.sqlite3
@@ -16,3 +17,4 @@ DEBUG=False
 # Настройки админ-панели
 ADMIN_PASSWORD=your_secure_admin_password_here
 SECRET_KEY=your_secret_key_for_flask_sessions_here
+

--- a/app/admin.py
+++ b/app/admin.py
@@ -1,6 +1,7 @@
 # app/admin.py
 from __future__ import annotations
 
+import logging
 from typing import Optional, List
 
 from aiogram import Router, F
@@ -12,17 +13,23 @@ from aiogram.types import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
 )
+from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError, TelegramNetworkError
 
 from app.database.requests import get_hot_leads
 from app.states import AdminStates
 from app.texts import get_text, get_button_text
 from app.calculator import get_goal_description, get_activity_description
+from config import ADMIN_CHAT_ID
+from utils.notifications import CONTACT_REQUEST_MESSAGE
 
 
 # ----------------------------
 # Router
 # ----------------------------
 admin = Router()
+
+
+logger = logging.getLogger(__name__)
 
 
 # ----------------------------
@@ -33,7 +40,7 @@ class Admin(Filter):
 
     def __init__(self, admin_ids: Optional[List[int]] = None):
         # Задай свой ID здесь или передавай извне.
-        self.admins = admin_ids or [310151740]
+        self.admins = admin_ids or [ADMIN_CHAT_ID]
 
     async def __call__(self, message: Message) -> bool:
         return bool(message.from_user and message.from_user.id in self.admins)
@@ -215,6 +222,50 @@ async def admin_prev_lead(callback: CallbackQuery, state: FSMContext) -> None:
     if leads:
         await _show_lead_card(callback, state, leads, prev_idx)
     await callback.answer()
+
+
+@admin.callback_query(F.data.startswith("lead_contact:"))
+async def admin_contact_lead(callback: CallbackQuery) -> None:
+    """Отправить лиду служебное сообщение по запросу админа."""
+    admin_id = callback.from_user.id if callback.from_user else None
+    logger.info("Admin %s pressed lead_contact button with data %s", admin_id, callback.data)
+
+    if admin_id != ADMIN_CHAT_ID:
+        logger.warning("Unauthorized lead_contact button press from %s", admin_id)
+        await callback.answer("Недостаточно прав", show_alert=True)
+        return
+
+    try:
+        _, tg_id_str = callback.data.split(":", 1)
+        lead_id = int(tg_id_str)
+    except (AttributeError, ValueError):
+        logger.warning("Invalid lead_contact payload: %s", callback.data)
+        await callback.answer("Некорректные данные", show_alert=True)
+        return
+
+    bot = callback.message.bot if callback.message else None
+    if bot is None:
+        logger.error("Cannot access bot instance to contact lead %s", lead_id)
+        await callback.answer("Ошибка отправки", show_alert=True)
+        return
+
+    try:
+        await bot.send_message(chat_id=lead_id, text=CONTACT_REQUEST_MESSAGE)
+    except TelegramForbiddenError as exc:
+        logger.warning("Lead %s blocked bot while sending contact prompt: %s", lead_id, exc)
+        await callback.answer("Бот не может написать лиду", show_alert=True)
+        return
+    except (TelegramBadRequest, TelegramNetworkError) as exc:
+        logger.error("Failed to deliver contact prompt to lead %s: %s", lead_id, exc)
+        await callback.answer("Не удалось отправить", show_alert=True)
+        return
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Unexpected error while sending contact prompt to %s: %s", lead_id, exc)
+        await callback.answer("Ошибка отправки", show_alert=True)
+        return
+
+    logger.info("Contact prompt delivered to lead %s", lead_id)
+    await callback.answer("Сообщение отправлено")
 
 
 @admin.callback_query(F.data == "admin_menu")

--- a/app/database/requests.py
+++ b/app/database/requests.py
@@ -1,16 +1,23 @@
 from datetime import datetime
+import logging
 
 from sqlalchemy import desc, select
 
 from app.database.models import User, async_session
+from utils.notifications import notify_new_lead
+
+
+logger = logging.getLogger(__name__)
 
 
 async def set_user(tg_id, username=None, first_name=None):
     """Создать или обновить пользователя"""
+    new_lead_created = False
     async with async_session() as session:
         user = await session.scalar(select(User).where(User.tg_id == tg_id))
-        
+
         if not user:
+            new_lead_created = True
             session.add(User(
                 tg_id=tg_id,
                 username=username,
@@ -25,8 +32,19 @@ async def set_user(tg_id, username=None, first_name=None):
             if first_name and user.first_name != first_name:
                 user.first_name = first_name
             user.updated_at = datetime.utcnow()
-            
+
         await session.commit()
+
+    if new_lead_created:
+        lead_payload = {
+            "tg_id": tg_id,
+            "username": username,
+            "first_name": first_name,
+        }
+        try:
+            await notify_new_lead(lead_payload)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("Failed to send new lead notification: %s", exc)
 
 
 async def get_user(tg_id):

--- a/app/user.py
+++ b/app/user.py
@@ -14,7 +14,12 @@ from functools import wraps
 from typing import Any
 
 from aiogram import F, Router
-from aiogram.exceptions import TelegramBadRequest, TelegramNetworkError, TelegramRetryAfter
+from aiogram.exceptions import (
+    TelegramBadRequest,
+    TelegramForbiddenError,
+    TelegramNetworkError,
+    TelegramRetryAfter,
+)
 from aiogram.filters import CommandStart
 from aiogram.fsm.context import FSMContext
 from aiogram.types import CallbackQuery, Message, URLInputFile
@@ -46,7 +51,8 @@ from app.keyboards import (
 from app.states import KBJUStates
 from app.texts import get_text, get_button_text
 from app.webhook import TimerService, WebhookService
-from config import CHANNEL_URL
+from utils.notifications import CONTACT_REQUEST_MESSAGE, notify_new_lead
+from config import CHANNEL_URL, ADMIN_CHAT_ID
 
 
 logger = logging.getLogger(__name__)
@@ -172,7 +178,33 @@ async def calculate_and_save_kbju(user_id: int, user_data: dict) -> dict:
         calculated_at=datetime.utcnow(),
         priority_score=PRIORITY_SCORES["new"],
     )
+    # Уведомляем админа карточкой с актуальными данными (не блокируем UI)
+    lead_payload = {
+        "tg_id": user_id,
+        "username": user_data.get("username"),
+        "first_name": user_data.get("first_name"),
+        "goal": user_data.get("goal"),
+        "calories": kbju.get("calories"),
+    }
+    asyncio.create_task(notify_new_lead(lead_payload))
     return kbju
+
+
+@user.message(F.reply_to_message, F.reply_to_message.text == CONTACT_REQUEST_MESSAGE)
+async def forward_lead_contact_response(message: Message) -> None:
+    """Переслать ответ лида админу после служебного сообщения."""
+    if not message.from_user:
+        return
+
+    lead_id = message.from_user.id
+    logger.info("Forwarding contact reply from lead %s to admin", lead_id)
+
+    try:
+        await message.forward(chat_id=ADMIN_CHAT_ID)
+    except (TelegramBadRequest, TelegramForbiddenError, TelegramNetworkError) as exc:
+        logger.error("Failed to forward contact reply from %s: %s", lead_id, exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Unexpected error while forwarding contact reply from %s: %s", lead_id, exc)
 
 
 async def show_kbju_results(callback: CallbackQuery, kbju: dict, goal: str):

--- a/config.py
+++ b/config.py
@@ -14,8 +14,16 @@ def _bool(value: str) -> bool:
     return str(value).lower() in ("1", "true", "yes", "y", "on")
 
 # Совместимость имён токена
-TOKEN = os.getenv("TOKEN") or os.getenv("BOT_TOKEN", "")
-BOT_TOKEN = TOKEN
+TELEGRAM_BOT_TOKEN = (
+    os.getenv("TELEGRAM_BOT_TOKEN")
+    or os.getenv("TOKEN")
+    or os.getenv("BOT_TOKEN", "")
+)
+TOKEN = TELEGRAM_BOT_TOKEN
+BOT_TOKEN = TELEGRAM_BOT_TOKEN
+
+# Администратор
+ADMIN_CHAT_ID = int(os.getenv("ADMIN_CHAT_ID", "310151740"))
 
 # База данных
 DB_URL = os.getenv("DB_URL", "sqlite+aiosqlite:///data/db.sqlite3")
@@ -31,6 +39,6 @@ CHANNEL_URL = os.getenv("CHANNEL_URL", "")
 DEBUG = _bool(os.getenv("DEBUG", "false"))
 
 # Проверка обязательных переменных
-if not TOKEN:
+if not TELEGRAM_BOT_TOKEN:
     print("⚠️ ВНИМАНИЕ: BOT_TOKEN не установлен!")
     print("Создайте .env файл и укажите BOT_TOKEN=your_bot_token_here")

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -1,0 +1,157 @@
+import asyncio
+import html
+import logging
+from typing import Any, Mapping, Optional, Tuple
+
+import aiohttp
+from aiohttp import ClientError, ClientTimeout
+
+from config import ADMIN_CHAT_ID, TELEGRAM_BOT_TOKEN
+
+TELEGRAM_API_URL = "https://api.telegram.org"
+CONTACT_REQUEST_MESSAGE = "Админ хочет с вами связаться, ответьте на это сообщение"
+
+logger = logging.getLogger(__name__)
+
+_GOAL_LABELS: Mapping[str, str] = {
+    "weight_loss": "Похудение",
+    "maintenance": "Поддержание",
+    "weight_gain": "Набор массы",
+}
+
+
+def _value_from_user(user: Mapping[str, Any] | Any, key: str) -> Any:
+    """Возвращает значение атрибута/ключа из произвольного объекта пользователя."""
+    if isinstance(user, Mapping):
+        return user.get(key)
+    return getattr(user, key, None)
+
+
+def _sanitize_username(username: Optional[str]) -> Optional[str]:
+    if not username:
+        return None
+    return username.lstrip("@")
+
+
+def _format_goal(goal: Optional[str]) -> str:
+    if not goal:
+        return "—"
+    goal_key = str(goal)
+    return _GOAL_LABELS.get(goal_key, goal_key)
+
+
+def _format_calories(calories: Any) -> str:
+    if calories in (None, ""):
+        return "—"
+    try:
+        return f"{int(float(calories))}"
+    except (TypeError, ValueError):
+        return str(calories)
+
+
+def build_lead_card(user: Mapping[str, Any] | Any) -> Tuple[str, dict]:
+    """Сформировать текст и клавиатуру карточки лида для уведомления админу."""
+    tg_id = _value_from_user(user, "tg_id")
+    if tg_id is None:
+        raise ValueError("tg_id is required to build lead card")
+
+    try:
+        tg_id_int = int(tg_id)
+    except (TypeError, ValueError) as exc:  # noqa: BLE001 - логируем понятную ошибку
+        raise ValueError(f"tg_id must be integer-compatible, got {tg_id!r}") from exc
+
+    first_name = _value_from_user(user, "first_name")
+    username_raw = _sanitize_username(_value_from_user(user, "username"))
+    goal = _format_goal(_value_from_user(user, "goal"))
+    calories = _format_calories(_value_from_user(user, "calories"))
+
+    display_name = first_name or username_raw or f"ID {tg_id_int}"
+    safe_name = html.escape(str(display_name))
+
+    username_line = (
+        f"💬 @{html.escape(username_raw)}\n" if username_raw else ""
+    )
+
+    mention_link = f'<a href="tg://user?id={tg_id_int}">Открыть профиль</a>'
+
+    text = (
+        "<b>Новый лид</b>\n"
+        f"👤 {safe_name}\n"
+        f"🆔 <code>{tg_id_int}</code>\n"
+        f"🎯 Цель: {html.escape(goal)}\n"
+        f"🔥 Калории: {html.escape(calories)}\n"
+        f"{username_line}"
+        f"{mention_link}"
+    )
+
+    if username_raw:
+        profile_url = f"https://t.me/{username_raw}"
+    else:
+        profile_url = f"tg://user?id={tg_id_int}"
+
+    reply_markup = {
+        "inline_keyboard": [
+            [{"text": "👤 Открыть профиль", "url": profile_url}],
+            [
+                {"text": "📨 Связаться", "callback_data": f"lead_contact:{tg_id_int}"},
+                {"text": "📝 Написать от бота", "callback_data": f"lead_reply:{tg_id_int}"},
+            ],
+        ]
+    }
+
+    return text, reply_markup
+
+
+async def send_telegram_message(
+    message: str,
+    *,
+    chat_id: int = ADMIN_CHAT_ID,
+    parse_mode: Optional[str] = None,
+    reply_markup: Optional[dict] = None,
+) -> None:
+    """Отправить сообщение через Telegram Bot API."""
+    if not TELEGRAM_BOT_TOKEN:
+        logger.warning("TELEGRAM_BOT_TOKEN is not set; skipping Telegram notification")
+        return
+
+    url = f"{TELEGRAM_API_URL}/bot{TELEGRAM_BOT_TOKEN}/sendMessage"
+    payload: dict[str, Any] = {
+        "chat_id": chat_id,
+        "text": message,
+        "disable_web_page_preview": True,
+    }
+    if parse_mode:
+        payload["parse_mode"] = parse_mode
+    if reply_markup:
+        payload["reply_markup"] = reply_markup
+
+    try:
+        timeout = ClientTimeout(total=10)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.post(url, json=payload) as response:
+                if response.status != 200:
+                    body: Optional[str] = None
+                    try:
+                        body = await response.text()
+                    except Exception:  # noqa: BLE001 - логируем, но не прерываем
+                        body = None
+                    logger.error(
+                        "Failed to send Telegram notification: status=%s, body=%s",
+                        response.status,
+                        body,
+                    )
+    except (ClientError, asyncio.TimeoutError) as exc:
+        logger.error("Error sending Telegram notification: %s", exc)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Unexpected error while sending Telegram notification: %s", exc)
+
+
+async def notify_new_lead(user: Mapping[str, Any] | Any) -> None:
+    """Собрать карточку лида и отправить админу."""
+    try:
+        text, markup = build_lead_card(user)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Failed to build lead card: %s", exc)
+        return
+
+    await send_telegram_message(text, parse_mode="HTML", reply_markup=markup)


### PR DESCRIPTION
## Summary
- add Telegram notification utility with reusable helpers and build an HTML lead card with quick-action buttons for the admin
- send admin Telegram alerts for new leads using TELEGRAM_BOT_TOKEN and ADMIN_CHAT_ID, including profile links and a contact fallback workflow
- trigger the admin notification after KBJU calculation without blocking the user flow and forward lead replies back to the admin chat

## Testing
- python -m compileall app utils

------
https://chatgpt.com/codex/tasks/task_e_68cd01cc50c08321abe5afaf68761e32