### PR TITLE
Implement bot reply flow for leads

### DIFF
--- a/app/states.py
+++ b/app/states.py
@@ -25,3 +25,4 @@ class AdminStates(StatesGroup):
     broadcast = State()
     statistics = State()
     viewing_leads = State()  # для пагинации лидов
+    lead_reply = State()

--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -170,9 +170,25 @@ async def notify_lead_card(user: Mapping[str, Any] | Any) -> None:
 def format_lead_message(name: str, contact: str) -> str:
     """Сформировать текст уведомления о новом лиде."""
 
-    safe_name = name or "Не указано"
-    safe_contact = contact or "контакт не указан"
-    return f"Новый лид: {safe_name}, {safe_contact}"
+    raw_name = (name or "").strip()
+    raw_contact = (contact or "").strip()
+
+    details: list[str] = []
+
+    if raw_name and not raw_name.isdigit() and raw_name.casefold() != "не указано":
+        details.append(raw_name)
+
+    contact_lower = raw_contact.casefold()
+    if (
+        raw_contact
+        and contact_lower not in {"—", "не указано", "контакт не указан"}
+        and not contact_lower.startswith("tg_id")
+    ):
+        details.append(raw_contact)
+
+    if details:
+        return f"Новый лид: {', '.join(details)}"
+    return "Новый лид"
 
 
 async def notify_lead_summary(name: str, contact: str) -> None:


### PR DESCRIPTION
## Summary
- add FSM state and handlers so admins can send bot messages from the "Написать от бота" button with proper validation and error handling
- reset lead navigation state when showing cards to avoid stale reply targets
- avoid exposing fallback TG identifiers in compact lead notifications when no contact info is available

## Testing
- python -m compileall app utils

------
https://chatgpt.com/codex/tasks/task_e_68cd340ec75c832191a390f8e201dc57