### PR TITLE
Add admin lead deletion flow

### DIFF
--- a/utils/notifications.py
+++ b/utils/notifications.py
@@ -100,6 +100,9 @@ def build_lead_card(user: Mapping[str, Any] | Any) -> Tuple[str, dict]:
                 {"text": "📨 Связаться", "callback_data": f"lead_contact:{tg_id_int}"},
                 {"text": "📝 Написать от бота", "callback_data": f"lead_reply:{tg_id_int}"},
             ],
+            [
+                {"text": "🗑 Удалить лида", "callback_data": f"lead_delete:{tg_id_int}"},
+            ],
         ]
     }
 


### PR DESCRIPTION
## Summary
- add async helper to remove users by tg_id with soft-delete fallback
- extend lead cards with an admin-only delete button
- implement admin-only lead deletion confirmation callbacks with logging and UI updates

## Testing
- python -m compileall app utils

------
https://chatgpt.com/codex/tasks/task_e_68cd6b0ba3208321b3c3ad3642c996ac