### PR TITLE
Implement stalled reminder for unfinished questionnaire

### DIFF
--- a/config.py
+++ b/config.py
@@ -73,6 +73,7 @@ DEBUG = _bool(os.getenv("DEBUG", "false"))
 ENABLE_HOT_LEAD_ALERTS = os.getenv("ENABLE_HOT_LEAD_ALERTS", "true").lower() == "true"
 
 # Напоминание пользователям, которые не завершили расчёт
+ENABLE_STALLED_REMINDER = _bool(os.getenv("ENABLE_STALLED_REMINDER", "true"))
 STALLED_REMINDER_DELAY_MIN = int(os.getenv("STALLED_REMINDER_DELAY_MIN", "120"))
 
 _missing_required: list[str] = []


### PR DESCRIPTION
## Summary
- enable the stalled reminder configuration flag and integrate it into TimerService
- add stalled reminder scheduling/cancellation in TimerService with resume callback handling
- restart or cancel the stalled reminder timer across questionnaire steps and final funnel transitions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce79ba43b48321a409ccf20dc04a65