### PR TITLE
Persist gender selection immediately

### DIFF
--- a/app/user.py
+++ b/app/user.py
@@ -1162,6 +1162,17 @@ async def process_gender(callback: CallbackQuery, state: FSMContext):
         gender = callback.data.split("_", 1)[1]  # male/female
         if gender not in {"male", "female"}:
             return
+
+        persist_result = await safe_db_operation(
+            update_user_data,
+            callback.from_user.id,
+            gender=gender,
+        )
+        if persist_result is False:
+            logger.warning(
+                "Failed to persist gender for user %s", callback.from_user.id
+            )
+
         await state.update_data(gender=gender)
 
         await callback.message.edit_text(get_text("questions.age"), parse_mode="HTML")


### PR DESCRIPTION
## Summary
- persist the user's gender in the database as soon as they choose it in the calculator flow
- log a warning if the persistence step fails so issues can be diagnosed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfcaa334808321a6a6c50f8d3a85b8