### PR TITLE
Fix admin panel password loading and simplify save flow

### DIFF
--- a/app/admin_panel.py
+++ b/app/admin_panel.py
@@ -5,13 +5,18 @@ import logging
 import os
 import secrets
 from functools import wraps
+from pathlib import Path
 
 from dotenv import load_dotenv
 from flask import Flask, flash, redirect, render_template, request, session, url_for
 from flask_wtf.csrf import CSRFProtect
 from werkzeug.security import check_password_hash, generate_password_hash
 
-load_dotenv()
+CURRENT_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = CURRENT_DIR.parent
+
+for env_path in (PROJECT_ROOT / ".env", CURRENT_DIR / ".env"):
+    load_dotenv(env_path, override=False)
 
 logger = logging.getLogger(__name__)
 
@@ -143,13 +148,6 @@ def save_text():
     is_message = request.form.get("is_message") == "1"
     photo_file_id = request.form.get("photo_file_id", "").strip()
     video_file_id = request.form.get("video_file_id", "").strip()
-    password = request.form.get("password", "")
-
-    if not _verify_password(password):
-        logger.info("Rejected save attempt for %s due to invalid password", text_key)
-        flash("Неверный пароль для сохранения", "error")
-        return redirect(url_for("edit_text", text_key=text_key))
-
     texts = load_texts()
     keys = text_key.split(".")
     current = texts

--- a/templates/edit_text.html
+++ b/templates/edit_text.html
@@ -77,12 +77,6 @@
                         </div>
                     {% endif %}
 
-                    <div class="mb-3">
-                        <label for="password" class="form-label">Пароль для сохранения:</label>
-                        <input type="password" class="form-control" id="password" name="password" required
-                               placeholder="Введите пароль админ-панели">
-                    </div>
-                    
                     <div class="d-grid gap-2 d-md-flex justify-content-md-end">
                         <a href="{{ url_for('index') }}" class="btn btn-secondary">Отмена</a>
                         <button type="submit" class="btn btn-success">💾 Сохранить</button>


### PR DESCRIPTION
## Summary
- load environment variables for the admin panel from the project root to ensure the configured password is used
- keep save operations behind login only by removing the additional password prompt from the edit form and handler

## Testing
- python -m compileall app utils

------
https://chatgpt.com/codex/tasks/task_e_68cfd85a0fd483219264c4fff1cb2987