### PR TITLE
feat: improve admin navigation and hide priority banner

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -30,6 +30,33 @@
             background-color: #f8f9fa;
             border-bottom: 1px solid #dee2e6;
         }
+        .section-card .card-header {
+            padding: 0;
+        }
+        .section-toggle {
+            width: 100%;
+            padding: 12px 16px;
+            border: none;
+            background: transparent;
+            font-size: 1.05rem;
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            color: #212529;
+            text-align: left;
+        }
+        .section-toggle:focus {
+            outline: none;
+            box-shadow: none;
+        }
+        .section-toggle:hover {
+            color: #0d6efd;
+        }
+        .toggle-icon {
+            transition: transform 0.2s ease;
+            font-size: 0.9rem;
+        }
         .btn-primary {
             background-color: #0d6efd;
             border-color: #0d6efd;

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,92 +23,108 @@
 
 {% macro render_texts(texts, prefix='') %}
     {% for key, value in texts.items() %}
-        {% if value is mapping %}
-            {% if 'text' in value and 'title' in value %}
+        {% set full_key = prefix ~ key %}
+        {% if full_key != 'hot_lead_working' %}
+            {% if value is mapping %}
+                {% if 'text' in value and 'title' in value %}
+                    <div class="card">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="mb-0">{{ value.title }}</h5>
+                            <a href="{{ url_for('edit_text', text_key=(prefix + key)) }}" class="btn btn-primary btn-sm">
+                                ✏️ Редактировать
+                            </a>
+                        </div>
+                        <div class="card-body">
+                            <div class="text-preview preview-content mb-3">{{ value.text }}</div>
+                            {% set photo_id = value.get('photo_file_id', '').strip() if value.get('photo_file_id') is string else '' %}
+                            {% set video_id = value.get('video_file_id', '').strip() if value.get('video_file_id') is string else '' %}
+                            <div class="small">
+                                <div class="mb-1">
+                                    {% if photo_id %}
+                                        📷 Фото прикреплено: <code>{{ photo_id }}</code>
+                                    {% else %}
+                                        <span class="text-muted">📷 Фото не прикреплено</span>
+                                    {% endif %}
+                                </div>
+                                <div>
+                                    {% if video_id %}
+                                        🎬 Видео прикреплено: <code>{{ video_id }}</code>
+                                    {% else %}
+                                        <span class="text-muted">🎬 Видео не прикреплено</span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                            <small class="text-muted d-block mt-2">Ключ: <span class="text-key">{{ prefix + key }}</span></small>
+                        </div>
+                    </div>
+                {% elif 'text' in value %}
+                    <div class="card">
+                        <div class="card-header d-flex justify-content-between align-items-center">
+                            <h5 class="mb-0">📨 {{ key.replace('_', ' ').title() }}</h5>
+                            <a href="{{ url_for('edit_text', text_key=(prefix + key)) }}" class="btn btn-primary btn-sm">
+                                ✏️ Редактировать пост
+                            </a>
+                        </div>
+                        <div class="card-body">
+                            <div class="text-preview preview-content mb-3">{{ value.text }}</div>
+                            <div class="small">
+                                {% set photo_id = value.get('photo_file_id', '').strip() if value.get('photo_file_id') is string else '' %}
+                                {% set video_id = value.get('video_file_id', '').strip() if value.get('video_file_id') is string else '' %}
+                                <div class="mb-1">
+                                    {% if photo_id %}
+                                        📷 Фото прикреплено: <code>{{ photo_id }}</code>
+                                    {% else %}
+                                        <span class="text-muted">📷 Фото не прикреплено</span>
+                                    {% endif %}
+                                </div>
+                                <div>
+                                    {% if video_id %}
+                                        🎬 Видео прикреплено: <code>{{ video_id }}</code>
+                                    {% else %}
+                                        <span class="text-muted">🎬 Видео не прикреплено</span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                            <small class="text-muted d-block mt-2">Ключ: <span class="text-key">{{ prefix + key }}</span></small>
+                        </div>
+                    </div>
+                {% else %}
+                    {% set collapse_id = 'section-' ~ full_key|replace('.', '-') %}
+                    <div class="card section-card">
+                        <div class="card-header">
+                            <button
+                                class="section-toggle"
+                                type="button"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#{{ collapse_id }}"
+                                aria-expanded="true"
+                                aria-controls="{{ collapse_id }}"
+                            >
+                                <span class="toggle-icon">▼</span>
+                                <span>📁 {{ key.title().replace('_', ' ') }}</span>
+                            </button>
+                        </div>
+                        <div id="{{ collapse_id }}" class="collapse show section-collapse">
+                            <div class="card-body">
+                                {{ render_texts(value, prefix + key + '.') }}
+                            </div>
+                        </div>
+                    </div>
+                {% endif %}
+            {% else %}
                 <div class="card">
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                        <h5 class="mb-0">{{ value.title }}</h5>
+                    <div class="card-body d-flex justify-content-between align-items-start">
+                        <div class="flex-grow-1 me-3">
+                            <strong>{{ key.replace('_', ' ').title() }}:</strong>
+                            <div class="text-preview preview-content mt-2">{{ value }}</div>
+                            <small class="text-muted">Ключ: <span class="text-key">{{ prefix + key }}</span></small>
+                        </div>
                         <a href="{{ url_for('edit_text', text_key=(prefix + key)) }}" class="btn btn-primary btn-sm">
                             ✏️ Редактировать
                         </a>
                     </div>
-                    <div class="card-body">
-                        <div class="text-preview preview-content mb-3">{{ value.text }}</div>
-                        {% set photo_id = value.get('photo_file_id', '').strip() if value.get('photo_file_id') is string else '' %}
-                        {% set video_id = value.get('video_file_id', '').strip() if value.get('video_file_id') is string else '' %}
-                        <div class="small">
-                            <div class="mb-1">
-                                {% if photo_id %}
-                                    📷 Фото прикреплено: <code>{{ photo_id }}</code>
-                                {% else %}
-                                    <span class="text-muted">📷 Фото не прикреплено</span>
-                                {% endif %}
-                            </div>
-                            <div>
-                                {% if video_id %}
-                                    🎬 Видео прикреплено: <code>{{ video_id }}</code>
-                                {% else %}
-                                    <span class="text-muted">🎬 Видео не прикреплено</span>
-                                {% endif %}
-                            </div>
-                        </div>
-                        <small class="text-muted d-block mt-2">Ключ: <span class="text-key">{{ prefix + key }}</span></small>
-                    </div>
-                </div>
-            {% elif 'text' in value %}
-                <div class="card">
-                    <div class="card-header d-flex justify-content-between align-items-center">
-                        <h5 class="mb-0">📨 {{ key.replace('_', ' ').title() }}</h5>
-                        <a href="{{ url_for('edit_text', text_key=(prefix + key)) }}" class="btn btn-primary btn-sm">
-                            ✏️ Редактировать пост
-                        </a>
-                    </div>
-                    <div class="card-body">
-                        <div class="text-preview preview-content mb-3">{{ value.text }}</div>
-                        <div class="small">
-                            {% set photo_id = value.get('photo_file_id', '').strip() if value.get('photo_file_id') is string else '' %}
-                            {% set video_id = value.get('video_file_id', '').strip() if value.get('video_file_id') is string else '' %}
-                            <div class="mb-1">
-                                {% if photo_id %}
-                                    📷 Фото прикреплено: <code>{{ photo_id }}</code>
-                                {% else %}
-                                    <span class="text-muted">📷 Фото не прикреплено</span>
-                                {% endif %}
-                            </div>
-                            <div>
-                                {% if video_id %}
-                                    🎬 Видео прикреплено: <code>{{ video_id }}</code>
-                                {% else %}
-                                    <span class="text-muted">🎬 Видео не прикреплено</span>
-                                {% endif %}
-                            </div>
-                        </div>
-                        <small class="text-muted d-block mt-2">Ключ: <span class="text-key">{{ prefix + key }}</span></small>
-                    </div>
-                </div>
-            {% else %}
-                <div class="card">
-                    <div class="card-header">
-                        <h5 class="mb-0">📁 {{ key.title().replace('_', ' ') }}</h5>
-                    </div>
-                    <div class="card-body">
-                        {{ render_texts(value, prefix + key + '.') }}
-                    </div>
                 </div>
             {% endif %}
-        {% else %}
-            <div class="card">
-                <div class="card-body d-flex justify-content-between align-items-start">
-                    <div class="flex-grow-1 me-3">
-                        <strong>{{ key.replace('_', ' ').title() }}:</strong>
-                        <div class="text-preview preview-content mt-2">{{ value }}</div>
-                        <small class="text-muted">Ключ: <span class="text-key">{{ prefix + key }}</span></small>
-                    </div>
-                    <a href="{{ url_for('edit_text', text_key=(prefix + key)) }}" class="btn btn-primary btn-sm">
-                        ✏️ Редактировать
-                    </a>
-                </div>
-            </div>
         {% endif %}
     {% endfor %}
 {% endmacro %}
@@ -124,9 +140,33 @@ function togglePreview() {
     previews.forEach(preview => {
         preview.style.display = showPreview ? 'block' : 'none';
     });
-    
+
     const btn = event.target;
     btn.textContent = showPreview ? '👁️ Скрыть превью' : '👁️ Показать превью';
 }
+
+document.querySelectorAll('.section-collapse').forEach((collapseEl) => {
+    collapseEl.addEventListener('show.bs.collapse', () => {
+        const toggleBtn = document.querySelector(`[data-bs-target="#${collapseEl.id}"]`);
+        if (toggleBtn) {
+            const icon = toggleBtn.querySelector('.toggle-icon');
+            if (icon) {
+                icon.textContent = '▼';
+            }
+            toggleBtn.setAttribute('aria-expanded', 'true');
+        }
+    });
+
+    collapseEl.addEventListener('hide.bs.collapse', () => {
+        const toggleBtn = document.querySelector(`[data-bs-target="#${collapseEl.id}"]`);
+        if (toggleBtn) {
+            const icon = toggleBtn.querySelector('.toggle-icon');
+            if (icon) {
+                icon.textContent = '▶';
+            }
+            toggleBtn.setAttribute('aria-expanded', 'false');
+        }
+    });
+});
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- hide the hot_lead_working message card from the admin index view
- add collapsible folders for nested text sections with toggle arrows
- style toggle controls for clearer navigation in the admin panel

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cff1e106288321aaa91102641e3c42