### PR TITLE
Reset drip stage when user re-engages

### DIFF
--- a/app/database/requests.py
+++ b/app/database/requests.py
@@ -42,6 +42,8 @@ async def set_user(tg_id: int, username: str | None = None, first_name: str | No
                 user.first_name = first_name
             user.last_activity_at = datetime.utcnow()
             user.updated_at = datetime.utcnow()
+            if getattr(user, "drip_stage", None) not in (None, 0):
+                user.drip_stage = 0
 
         await session.commit()
 
@@ -216,6 +218,8 @@ async def update_last_activity(tg_id: int) -> bool:
 
         user.last_activity_at = datetime.utcnow()
         user.updated_at = datetime.utcnow()
+        if getattr(user, "drip_stage", None) not in (None, 0):
+            user.drip_stage = 0
         await session.commit()
         return True
 


### PR DESCRIPTION
## Summary
- reset a lead's drip stage to zero when they return via /start so the follow-up sequence can restart
- clear drip stage on any tracked user activity update to avoid blocking future reminder messages

## Testing
- python -m compileall app utils

------
https://chatgpt.com/codex/tasks/task_e_68d3b941a58c83219d967f3ce042ade2