### PR TITLE
Add media upload support in admin text editor

### DIFF
--- a/app/admin_panel.py
+++ b/app/admin_panel.py
@@ -4,16 +4,24 @@ import json
 import logging
 import os
 import secrets
+import sys
 from functools import wraps
 from pathlib import Path
-
-from dotenv import load_dotenv
-from flask import Flask, flash, redirect, render_template, request, session, url_for
-from flask_wtf.csrf import CSRFProtect
-from werkzeug.security import check_password_hash, generate_password_hash
+from typing import Any
 
 CURRENT_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = CURRENT_DIR.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import requests
+from dotenv import load_dotenv
+from flask import Flask, flash, jsonify, redirect, render_template, request, session, url_for
+from flask_wtf.csrf import CSRFProtect
+from requests import RequestException
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from config import ADMIN_CHAT_ID, TELEGRAM_BOT_TOKEN
 
 for env_path in (PROJECT_ROOT / ".env", CURRENT_DIR / ".env"):
     load_dotenv(env_path, override=False)
@@ -77,6 +85,30 @@ def save_texts(texts):
     """Persist bot texts to storage."""
     with open(TEXTS_FILE, "w", encoding="utf-8") as fp:
         json.dump(texts, fp, ensure_ascii=False, indent=2)
+
+
+def _extract_file_id(media_type: str, result_payload: Any) -> str | None:
+    """Получить file_id из ответа Telegram в зависимости от типа медиа."""
+
+    if not isinstance(result_payload, dict):
+        return None
+
+    if media_type == "photo":
+        photos = result_payload.get("photo")
+        if isinstance(photos, list) and photos:
+            last_photo = photos[-1]
+            if isinstance(last_photo, dict):
+                file_id = last_photo.get("file_id")
+                if isinstance(file_id, str):
+                    return file_id
+        return None
+
+    video = result_payload.get("video")
+    if isinstance(video, dict):
+        file_id = video.get("file_id")
+        if isinstance(file_id, str):
+            return file_id
+    return None
 
 
 def login_required(func):
@@ -182,6 +214,100 @@ def save_text():
     save_texts(texts)
     flash("Текст успешно сохранен", "success")
     return redirect(url_for("index"))
+
+
+@app.route("/upload_media", methods=["POST"])
+@login_required
+def upload_media():
+    if not TELEGRAM_BOT_TOKEN:
+        logger.error("Cannot upload media: TELEGRAM_BOT_TOKEN is not configured")
+        return (
+            jsonify({"ok": False, "error": "Не настроен токен бота для загрузки файлов."}),
+            500,
+        )
+
+    if ADMIN_CHAT_ID is None:
+        logger.error("Cannot upload media: ADMIN_CHAT_ID is not configured")
+        return (
+            jsonify({"ok": False, "error": "Не указан ADMIN_CHAT_ID для загрузки файлов."}),
+            500,
+        )
+
+    media_type = request.form.get("media_type", "")
+    if media_type not in {"photo", "video"}:
+        return jsonify({"ok": False, "error": "Неверный тип медиа."}), 400
+
+    file = request.files.get("media")
+    if file is None or not file.filename:
+        return jsonify({"ok": False, "error": "Выберите файл для загрузки."}), 400
+
+    telegram_method = "sendPhoto" if media_type == "photo" else "sendVideo"
+    telegram_field = "photo" if media_type == "photo" else "video"
+    endpoint = f"https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/{telegram_method}"
+
+    if hasattr(file, "stream"):
+        try:
+            file.stream.seek(0)
+        except OSError:
+            logger.debug("Unable to seek upload stream for %s", file.filename)
+
+    files = {
+        telegram_field: (
+            file.filename or f"{media_type}.bin",
+            file.stream,
+            file.mimetype or "application/octet-stream",
+        )
+    }
+    data = {
+        "chat_id": str(ADMIN_CHAT_ID),
+        "disable_notification": "true",
+    }
+
+    try:
+        response = requests.post(endpoint, data=data, files=files, timeout=30)
+    except RequestException as exc:
+        logger.error("Failed to send %s to Telegram: %s", media_type, exc)
+        return (
+            jsonify({"ok": False, "error": "Не удалось загрузить файл. Попробуйте позже."}),
+            502,
+        )
+
+    try:
+        payload = response.json()
+    except ValueError:
+        logger.error(
+            "Telegram response for %s is not JSON. Status: %s", telegram_method, response.status_code
+        )
+        return (
+            jsonify({"ok": False, "error": "Telegram вернул некорректный ответ."}),
+            502,
+        )
+
+    if not response.ok or not payload.get("ok"):
+        description = payload.get("description") if isinstance(payload, dict) else None
+        logger.error(
+            "Telegram %s failed: status=%s, payload=%s", telegram_method, response.status_code, payload
+        )
+        message = "Не удалось загрузить файл в Telegram."
+        if description:
+            message = f"{message} {description}"
+        return jsonify({"ok": False, "error": message}), 502
+
+    file_id = _extract_file_id(media_type, payload.get("result"))
+    if not file_id:
+        logger.error("Could not extract file_id from Telegram %s response: %s", telegram_method, payload)
+        return (
+            jsonify({"ok": False, "error": "Не удалось получить file_id из ответа Telegram."}),
+            502,
+        )
+
+    logger.info(
+        "Uploaded %s for text '%s' with file_id=%s",
+        media_type,
+        request.form.get("text_key", "<unknown>"),
+        file_id,
+    )
+    return jsonify({"ok": True, "file_id": file_id})
 
 
 @app.route("/health")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ Flask==3.0.3
 Flask-Limiter==3.12
 gunicorn==22.0.0
 Flask-WTF==1.2.1
+requests==2.32.3

--- a/templates/edit_text.html
+++ b/templates/edit_text.html
@@ -61,6 +61,22 @@
                                     value="{{ text_data.get('photo_file_id', '') }}"
                                 >
                                 <div class="form-text">Оставьте пустым, чтобы удалить фото.</div>
+                                <div class="mt-2">
+                                    <label for="photo_upload_input" class="form-label">Или загрузите новое фото:</label>
+                                    <div class="input-group">
+                                        <input type="file" class="form-control" id="photo_upload_input" accept="image/*">
+                                        <button
+                                            type="button"
+                                            class="btn btn-outline-primary"
+                                            id="photo_upload_button"
+                                            onclick="uploadMedia('photo')"
+                                        >
+                                            Загрузить
+                                        </button>
+                                    </div>
+                                    <div class="form-text">Файл отправится в Telegram и вернёт готовый file_id.</div>
+                                    <div class="small text-muted mt-1" id="photo_upload_status"></div>
+                                </div>
                             </div>
                             <div class="col-md-6">
                                 <label for="video_file_id" class="form-label">Добавить видео к посту</label>
@@ -73,6 +89,22 @@
                                     value="{{ text_data.get('video_file_id', '') }}"
                                 >
                                 <div class="form-text">Оставьте пустым, чтобы удалить видео.</div>
+                                <div class="mt-2">
+                                    <label for="video_upload_input" class="form-label">Или загрузите новое видео:</label>
+                                    <div class="input-group">
+                                        <input type="file" class="form-control" id="video_upload_input" accept="video/*">
+                                        <button
+                                            type="button"
+                                            class="btn btn-outline-primary"
+                                            id="video_upload_button"
+                                            onclick="uploadMedia('video')"
+                                        >
+                                            Загрузить
+                                        </button>
+                                    </div>
+                                    <div class="form-text">После загрузки file_id заполнится автоматически.</div>
+                                    <div class="small text-muted mt-1" id="video_upload_status"></div>
+                                </div>
                             </div>
                         </div>
                     {% endif %}
@@ -103,18 +135,32 @@
                         {% set current_video = (text_data.get('video_file_id', '') | default('')) if is_message else '' %}
                         <ul class="small mb-0">
                             <li>
-                                {% if current_photo %}
-                                    📷 Фото: <code>{{ current_photo }}</code>
-                                {% else %}
-                                    <span class="text-muted">Фото не прикреплено</span>
-                                {% endif %}
+                                <span
+                                    id="photo_preview_attached"
+                                    class="{% if not current_photo %}d-none{% endif %}"
+                                >
+                                    📷 Фото: <code id="photo_preview_code">{{ current_photo }}</code>
+                                </span>
+                                <span
+                                    id="photo_preview_empty"
+                                    class="text-muted {% if current_photo %}d-none{% endif %}"
+                                >
+                                    Фото не прикреплено
+                                </span>
                             </li>
                             <li>
-                                {% if current_video %}
-                                    🎬 Видео: <code>{{ current_video }}</code>
-                                {% else %}
-                                    <span class="text-muted">Видео не прикреплено</span>
-                                {% endif %}
+                                <span
+                                    id="video_preview_attached"
+                                    class="{% if not current_video %}d-none{% endif %}"
+                                >
+                                    🎬 Видео: <code id="video_preview_code">{{ current_video }}</code>
+                                </span>
+                                <span
+                                    id="video_preview_empty"
+                                    class="text-muted {% if current_video %}d-none{% endif %}"
+                                >
+                                    Видео не прикреплено
+                                </span>
                             </li>
                         </ul>
                     </div>
@@ -138,17 +184,112 @@
 
 <script>
 // Предварительный просмотр в реальном времени
-document.getElementById('text_content').addEventListener('input', function() {
-    const preview = document.getElementById('preview');
-    let text = this.value;
-    
-    // Простая замена HTML тегов для предварительного просмотра
-    text = text.replace(/<b>(.*?)<\/b>/g, '<strong>$1</strong>');
-    text = text.replace(/<i>(.*?)<\/i>/g, '<em>$1</em>');
-    text = text.replace(/<code>(.*?)<\/code>/g, '<code>$1</code>');
-    text = text.replace(/\n/g, '<br>');
-    
-    preview.innerHTML = text;
-});
+const textContentElement = document.getElementById('text_content');
+if (textContentElement) {
+    textContentElement.addEventListener('input', function() {
+        const preview = document.getElementById('preview');
+        if (!preview) {
+            return;
+        }
+
+        let text = this.value;
+
+        // Простая замена HTML тегов для предварительного просмотра
+        text = text.replace(/<b>(.*?)<\/b>/g, '<strong>$1</strong>');
+        text = text.replace(/<i>(.*?)<\/i>/g, '<em>$1</em>');
+        text = text.replace(/<code>(.*?)<\/code>/g, '<code>$1</code>');
+        text = text.replace(/\n/g, '<br>');
+
+        preview.innerHTML = text;
+    });
+}
+
+{% if is_message %}
+const csrfInput = document.querySelector('input[name="csrf_token"]');
+const uploadUrl = "{{ url_for('upload_media') }}";
+
+function updatePreview(mediaType, fileId) {
+    const attached = document.getElementById(`${mediaType}_preview_attached`);
+    const empty = document.getElementById(`${mediaType}_preview_empty`);
+    const code = document.getElementById(`${mediaType}_preview_code`);
+
+    if (!attached || !empty) {
+        return;
+    }
+
+    if (fileId) {
+        if (code) {
+            code.textContent = fileId;
+        }
+        attached.classList.remove('d-none');
+        empty.classList.add('d-none');
+    } else {
+        if (code) {
+            code.textContent = '';
+        }
+        attached.classList.add('d-none');
+        empty.classList.remove('d-none');
+    }
+}
+
+async function uploadMedia(mediaType) {
+    const fileInput = document.getElementById(`${mediaType}_upload_input`);
+    const statusElement = document.getElementById(`${mediaType}_upload_status`);
+    const targetInput = document.getElementById(`${mediaType}_file_id`);
+    const uploadButton = document.getElementById(`${mediaType}_upload_button`);
+
+    if (!fileInput || !statusElement || !targetInput || !uploadButton) {
+        return;
+    }
+
+    const file = fileInput.files[0];
+    if (!file) {
+        statusElement.textContent = 'Сначала выберите файл.';
+        statusElement.className = 'small text-danger mt-1';
+        return;
+    }
+
+    const csrfToken = csrfInput ? csrfInput.value : '';
+    const formData = new FormData();
+    formData.append('media_type', mediaType);
+    formData.append('media', file);
+    formData.append('text_key', '{{ text_key }}');
+    if (csrfToken) {
+        formData.append('csrf_token', csrfToken);
+    }
+
+    statusElement.textContent = 'Загружаем файл в Telegram...';
+    statusElement.className = 'small text-muted mt-1';
+    uploadButton.disabled = true;
+    fileInput.disabled = true;
+
+    try {
+        const response = await fetch(uploadUrl, {
+            method: 'POST',
+            body: formData,
+        });
+
+        const data = await response.json().catch(() => null);
+        if (!response.ok || !data || !data.ok) {
+            const errorMessage = data && data.error ? data.error : 'Не удалось загрузить файл.';
+            statusElement.textContent = errorMessage;
+            statusElement.className = 'small text-danger mt-1';
+            return;
+        }
+
+        targetInput.value = data.file_id;
+        updatePreview(mediaType, data.file_id);
+        statusElement.textContent = 'Файл загружен. file_id подставлен автоматически.';
+        statusElement.className = 'small text-success mt-1';
+    } catch (error) {
+        statusElement.textContent = 'Ошибка соединения. Попробуйте ещё раз.';
+        statusElement.className = 'small text-danger mt-1';
+    } finally {
+        uploadButton.disabled = false;
+        fileInput.disabled = false;
+        fileInput.value = '';
+    }
+}
+{% endif %}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- allow the admin panel to upload photos and videos to Telegram and automatically capture file_id values
- extend the text editor UI with media upload controls, live status, and preview updates
- add the requests dependency required for Telegram Bot API uploads

## Testing
- python -m compileall app utils

------
https://chatgpt.com/codex/tasks/task_e_68d4fdd4497c8321929e4e69079a5518