### PR TITLE
Handle media offer messages when confirming lead request

### DIFF
--- a/app/user/kbju.py
+++ b/app/user/kbju.py
@@ -525,15 +525,41 @@ async def process_lead_request(callback: CallbackQuery) -> None:
                 exc,
             )
 
-    await callback.message.edit_text(
-        get_text(
-            "hot_lead_success",
-            user_id=callback.from_user.id,
-            username=callback.from_user.username or get_text("fallbacks.username_unknown"),
-        ),
-        reply_markup=back_to_menu(),
-        parse_mode="HTML",
+    success_text = get_text(
+        "hot_lead_success",
+        user_id=callback.from_user.id,
+        username=callback.from_user.username or get_text("fallbacks.username_unknown"),
     )
+    reply_markup = back_to_menu()
+
+    async def _send_success_message() -> None:
+        try:
+            await callback.message.edit_reply_markup()
+        except TelegramBadRequest:
+            pass
+        await callback.message.answer(
+            success_text,
+            reply_markup=reply_markup,
+            parse_mode="HTML",
+        )
+
+    try:
+        if callback.message.text:
+            await callback.message.edit_text(
+                success_text,
+                reply_markup=reply_markup,
+                parse_mode="HTML",
+            )
+        elif callback.message.caption:
+            await callback.message.edit_caption(
+                success_text,
+                reply_markup=reply_markup,
+                parse_mode="HTML",
+            )
+        else:
+            await _send_success_message()
+    except TelegramBadRequest:
+        await _send_success_message()
     await callback.answer()
 
 


### PR DESCRIPTION
## Summary
- gracefully handle successful lead requests sent from photo offers by editing the caption instead of the text
- fall back to sending a new success message when the original message cannot be modified and strip its keyboard to prevent repeated submissions

## Testing
- python -m compileall app utils

------
https://chatgpt.com/codex/tasks/task_e_68d517f4cd2c8321ba5c96fd8d669f55