### PR TITLE
Send hot lead success message as separate card

### DIFF
--- a/app/user/kbju.py
+++ b/app/user/kbju.py
@@ -543,23 +543,7 @@ async def process_lead_request(callback: CallbackQuery) -> None:
             parse_mode="HTML",
         )
 
-    try:
-        if callback.message.text:
-            await callback.message.edit_text(
-                success_text,
-                reply_markup=reply_markup,
-                parse_mode="HTML",
-            )
-        elif callback.message.caption:
-            await callback.message.edit_caption(
-                success_text,
-                reply_markup=reply_markup,
-                parse_mode="HTML",
-            )
-        else:
-            await _send_success_message()
-    except TelegramBadRequest:
-        await _send_success_message()
+    await _send_success_message()
     await callback.answer()
 
 


### PR DESCRIPTION
## Summary
- always send the hot lead success response as a separate text card instead of editing the existing media message
- keep removing the inline keyboard from the previous message before posting the confirmation

## Testing
- python -m compileall app utils

------
https://chatgpt.com/codex/tasks/task_e_68d51ad5de988321ba71f45a1ebd367f