### PR TITLE
Adjust macros for weight gain goal

### DIFF
--- a/app/calculator.py
+++ b/app/calculator.py
@@ -60,9 +60,14 @@ class KBJUCalculator:
         calories_maintenance = bmr * cls.ACTIVITY_COEFFICIENTS[activity]
         calories_target = calories_maintenance * (1 + cls.GOAL_ADJUSTMENTS[goal])
 
-        proteins = round(weight * 1.8)                          # 1.8 г/кг
-        fats = round(calories_target * 0.25 / 9)                # 25% калорий
-        carbs = round((calories_target - proteins * 4 - fats * 9) / 4)
+        if goal == "weight_gain":
+            proteins = round(weight * 2.0)                      # 2 г/кг
+            fats = round(weight * 1.1)                          # 1.1 г/кг
+            carbs = round((calories_target - proteins * 4 - fats * 9) / 4)
+        else:
+            proteins = round(weight * 1.8)                      # 1.8 г/кг
+            fats = round(calories_target * 0.25 / 9)            # 25% калорий
+            carbs = round((calories_target - proteins * 4 - fats * 9) / 4)
 
         return {
             "calories": round(calories_target),


### PR DESCRIPTION
## Summary
- adjust macronutrient targets when the user selects the weight gain goal
- increase protein and fat calculations for weight gain to match the new formula while keeping other goals unchanged

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d540f8370c8321bd32717a2f937bfa