### PR TITLE
Fix private chat filters for aiogram enums

### DIFF
--- a/app/admin.py
+++ b/app/admin.py
@@ -4,17 +4,18 @@ from __future__ import annotations
 import logging
 from typing import Optional, List
 
-from aiogram import Router, F
+from aiogram import F, Router
+from aiogram.enums import ChatType
+from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError, TelegramNetworkError
 from aiogram.filters import Command, Filter
 from aiogram.fsm.context import FSMContext
 from aiogram.types import (
-    Message,
     CallbackQuery,
+    ForceReply,
     InlineKeyboardButton,
     InlineKeyboardMarkup,
-    ForceReply,
+    Message,
 )
-from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError, TelegramNetworkError
 
 from app.database.requests import get_hot_leads
 from app.contact_requests import contact_request_registry
@@ -47,7 +48,7 @@ def _is_authorized_admin(message: Message) -> bool:
     if not message.from_user or message.from_user.id != ADMIN_CHAT_ID:
         return False
 
-    if message.chat.type != "private" or message.chat.id != ADMIN_CHAT_ID:
+    if message.chat.type != ChatType.PRIVATE or message.chat.id != ADMIN_CHAT_ID:
         return False
 
     return True
@@ -248,14 +249,14 @@ async def _show_lead_card(
 # ----------------------------
 # Handlers
 # ----------------------------
-@admin.message(Admin(), Command("admin"), F.chat.type == "private")
+@admin.message(Admin(), Command("admin"), F.chat.type == ChatType.PRIVATE)
 async def admin_home(message: Message) -> None:
     """Приветственная надпись админ-панели."""
     logger.debug("/admin entered by %s", message.from_user.id if message.from_user else "unknown")
     await message.answer(_admin_menu_text(), parse_mode="HTML")
 
 
-@admin.message(Admin(), Command("leads"), F.chat.type == "private")
+@admin.message(Admin(), Command("leads"), F.chat.type == ChatType.PRIVATE)
 async def admin_leads(message: Message, state: FSMContext) -> None:
     """Показать лиды (сразу открываем 1-ю карточку)."""
     leads = await get_hot_leads()

--- a/app/user/contact.py
+++ b/app/user/contact.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from aiogram import Router
+from aiogram.enums import ChatType
 from aiogram.exceptions import TelegramBadRequest, TelegramForbiddenError, TelegramNetworkError
 from aiogram.types import Message
 
@@ -25,7 +26,7 @@ def register(router: Router) -> None:
 async def _is_contact_response(message: Message) -> bool:
     if not message.from_user:
         return False
-    if message.chat.type != "private":
+    if message.chat.type != ChatType.PRIVATE:
         return False
     if message.reply_to_message and message.reply_to_message.text == CONTACT_REQUEST_MESSAGE:
         return True

--- a/app/user/general.py
+++ b/app/user/general.py
@@ -7,6 +7,7 @@ import logging
 from aiogram import F, Router
 from aiogram.exceptions import TelegramBadRequest
 from aiogram.filters import Command, CommandStart
+from aiogram.enums import ChatType
 from aiogram.types import CallbackQuery, Message, URLInputFile
 
 from app.calculator import get_activity_description
@@ -21,9 +22,13 @@ logger = logging.getLogger(__name__)
 
 
 def register(router: Router) -> None:
-    router.message.register(cmd_start, CommandStart(), F.chat.type == "private")
-    router.message.register(cmd_ping, Command("ping"), F.chat.type == "private")
-    router.message.register(cmd_contact_author, Command("contact_author"), F.chat.type == "private")
+    router.message.register(cmd_start, CommandStart(), F.chat.type == ChatType.PRIVATE)
+    router.message.register(cmd_ping, Command("ping"), F.chat.type == ChatType.PRIVATE)
+    router.message.register(
+        cmd_contact_author,
+        Command("contact_author"),
+        F.chat.type == ChatType.PRIVATE,
+    )
     router.callback_query.register(show_main_menu, F.data == "main_menu")
     router.callback_query.register(show_profile, F.data == "profile")
 

--- a/app/user/lifecycle.py
+++ b/app/user/lifecycle.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any
 
 from aiogram import F, Router
-from aiogram.enums import ChatMemberStatus
+from aiogram.enums import ChatMemberStatus, ChatType
 from aiogram.types import ChatMemberUpdated
 
 from app.database.requests import delete_user_by_tg_id, get_user
@@ -19,7 +19,10 @@ logger = logging.getLogger(__name__)
 
 
 def register(router: Router) -> None:
-    router.my_chat_member.register(handle_private_chat_member_update, F.chat.type == "private")
+    router.my_chat_member.register(
+        handle_private_chat_member_update,
+        F.chat.type == ChatType.PRIVATE,
+    )
 
 
 async def handle_private_chat_member_update(event: ChatMemberUpdated) -> None:


### PR DESCRIPTION
## Summary
- update user and admin routers to compare chat types against aiogram's ChatType enum
- ensure contact filters also use the enum so private handlers still run on aiogram 3.22+

## Testing
- python -m compileall app *(fails: SyntaxError in pre-existing app/user/kbju.py line 601)*

------
https://chatgpt.com/codex/tasks/task_e_68d7c1be9f288321853f827550cdfb07