### PR TITLE
Fix syntax error caused by stray decorators in KBJU flow

### DIFF
--- a/app/user/kbju.py
+++ b/app/user/kbju.py
@@ -595,7 +595,3 @@ async def process_priority(callback: CallbackQuery) -> None:
         )
 
     await callback.answer()
-
-
-@rate_limit
-@error_handler


### PR DESCRIPTION
## Summary
- remove stray decorators left at the end of the KBJU priority handler that caused a syntax error during import

## Testing
- python -m compileall app/user/kbju.py


------
https://chatgpt.com/codex/tasks/task_e_68d7c3d1862c8321aed963449d081894