### PR TITLE
Remove priority selection prompt from delayed offer flow

### DIFF
--- a/app/keyboards.py
+++ b/app/keyboards.py
@@ -44,15 +44,6 @@ def funnel_keyboard() -> InlineKeyboardMarkup:
     ])
 
 
-# Приоритеты для горячих лидов
-def priority_keyboard() -> InlineKeyboardMarkup:
-    return InlineKeyboardMarkup(inline_keyboard=[
-        [InlineKeyboardButton(text=get_button_text("priority_nutrition"), callback_data="priority_nutrition")],
-        [InlineKeyboardButton(text=get_button_text("priority_training"),  callback_data="priority_training")],
-        [InlineKeyboardButton(text=get_button_text("priority_schedule"),  callback_data="priority_schedule")],
-    ])
-
-
 # Клавиатура профиля пользователя
 def profile_keyboard() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=[


### PR DESCRIPTION
## Summary
- remove the priority selection keyboard and callback from the user funnel
- send the consultation offer immediately when a user accepts the delayed offer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7c5d9682483219fcb6d2c14e907c5