### PR TITLE
Fix default SQLite storage directory to avoid permission issues

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,7 +58,8 @@ BOT_TOKEN = TELEGRAM_BOT_TOKEN
 ADMIN_CHAT_ID = _int(os.getenv("ADMIN_CHAT_ID"), field_name="ADMIN_CHAT_ID")
 
 # База данных
-DB_URL = os.getenv("DB_URL", "sqlite+aiosqlite:///data/db.sqlite3")
+# Храним SQLite-базу в каталоге проекта, чтобы избежать прав на /data
+DB_URL = os.getenv("DB_URL", "sqlite+aiosqlite:///./data/db.sqlite3")
 
 # Webhook для интеграции с n8n
 N8N_WEBHOOK_URL = os.getenv("N8N_WEBHOOK_URL", "")


### PR DESCRIPTION
## Summary
- default the SQLite database URL to a project-local ./data directory to avoid permission errors on /data
- document the intent with an inline comment so deployments keep working without elevated rights

## Testing
- python -m compileall config.py

------
https://chatgpt.com/codex/tasks/task_e_68d7f2cd136c8321bdcacf2b4651aee9