### PR TITLE
Add retries around transient database errors

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -25,6 +25,10 @@ VALIDATION_LIMITS = {
 # Безопасность
 MAX_TEXT_LENGTH = 100
 DB_OPERATION_TIMEOUT = 10.0  # seconds
+# Количество повторов при временных ошибках БД (например, database is locked)
+DB_OPERATION_RETRIES = 3
+# Базовая пауза между повторами (будет увеличиваться линейно)
+DB_OPERATION_RETRY_DELAY = 0.5  # seconds
 
 # Статусы воронки лидов
 FUNNEL_STATUSES = {


### PR DESCRIPTION
## Summary
- add retry configuration constants for database operations
- retry safe_db_operation on transient SQLAlchemy operational errors with backoff logging

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d7f55c02d08321a8ca25f2eb0d2637